### PR TITLE
URL encode the opt-in-message anchor

### DIFF
--- a/jekyll/_includes/nav.html
+++ b/jekyll/_includes/nav.html
@@ -12,8 +12,8 @@
                 <a class="nav__text" data-nohash="true" href="https://s.userzoom.com/m/MSBDMTBTMTE5" target="_blank">Feedback</a>
             </li>
             <li class="nav__item"><strong>
-                <a class="nav__text" href="http://www.theguardian.com/preference/platform/mobile?page=http%3A%2F%2Fwww.theguardian.com%2Fuk%3Fview%3Dmobile">Try it »</a>
-                <a class="nav__text--mobile" href="http://www.theguardian.com/preference/platform/mobile?page=http%3A%2F%2Fwww.theguardian.com%2Fuk%3Fview%3Dmobile#opt-in-message">Try it »</a>
+                <a class="nav__text" href="http://www.theguardian.com/preference/platform/mobile?page=http%3A%2F%2Fwww.theguardian.com%2Fuk%3Fview%3Dmobile%23opt-in-message">Try it »</a>
+                <a class="nav__text--mobile" href="http://www.theguardian.com/preference/platform/mobile?page=http%3A%2F%2Fwww.theguardian.com%2Fuk%3Fview%3Dmobile%23opt-in-message">Try it »</a>
             </strong></li>
         </ul>
 

--- a/jekyll/_layouts/homepage.html
+++ b/jekyll/_layouts/homepage.html
@@ -11,7 +11,7 @@ layout: base
                     <div class="homepage__section-description">
                         {{ page.proposition | markdownify }}
                     </div>
-                    <a href="http://www.theguardian.com/preference/platform/mobile?page=http%3A%2F%2Fwww.theguardian.com%2Fuk%3Fview%3Dmobile#opt-in-message" id="homepage__try-ngw-link"><i class="i i-arrow-right-blue"></i><i class="i i-arrow-right-white"></i> Try the beta</a>
+                    <a href="http://www.theguardian.com/preference/platform/mobile?page=http%3A%2F%2Fwww.theguardian.com%2Fuk%3Fview%3Dmobile%23opt-in-message" id="homepage__try-ngw-link"><i class="i i-arrow-right-blue"></i><i class="i i-arrow-right-white"></i> Try the beta</a>
                 </div>
                 <div class="homepage__section-image-container">
                     <img class="homepage__section-image" alt="" src="/assets/images/devices.png"/>


### PR DESCRIPTION
Some browers won't redirect the hash if it's not encoded, Eg.

```
curl -i 'http://www.theguardian.com/preference/platform/mobile?page=http%3A%2F%2Fwww.theguardian.com%2Fuk%3Fview%3Dmobile%23opt-in-message'
```

/cc @rich-nguyen @mattosborn take note :)
