### PR TITLE
Set Google Analytics siteSpeedSampleRate to 100

### DIFF
--- a/jekyll/_includes/head.html
+++ b/jekyll/_includes/head.html
@@ -27,7 +27,7 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', 'UA-47631239-1', 'theguardian.com');
+        ga('create', 'UA-47631239-1', 'theguardian.com', {'siteSpeedSampleRate': 100});
       ga('send', 'pageview');
     </script>
 


### PR DESCRIPTION
Google Analytics has some amazing site speed/performance monitoring features (the best i've seen). But by default the audience sampling size for such metrics is only 1%. 

This PR sets the sample rate to 100%. As I want to play and learn from these features :wink: 

More details here: https://support.google.com/analytics/answer/1205784?hl=en-GB
