### PR TITLE
Remove D2 iframe

### DIFF
--- a/jekyll/_layouts/article.html
+++ b/jekyll/_layouts/article.html
@@ -43,8 +43,6 @@ layout: main
     {% endcomment %}
 {% if page.discussion %}
 <h2>Comments</h2>
-<br />
-<iframe height="600px" allowtransparency="true" frameborder="0" border="0" style="border:1px solid #ccc; padding:0 10px; max-width:720px; width:100%" role="application" horizontalscrolling="no" name="d2-iframe" src="http://discussion.theguardian.com/discussion/{{ page.discussion }}?commentpage=1&amp;orderby=newest&amp;threads=collapsed&amp;tab=all&amp;iframe=true&amp;noposting=true"></iframe>
-<p style="color:#666;"><a href="http://www.theguardian.com/{{ page.discussion}}">Click here</a> to see the comment page on theguardian.com.</p>
+<p style="color:#666;"><a href="http://www.theguardian.com/discussion/{{ page.discussion}}">Click here</a> to see the comment page on theguardian.com.</p>
 {% endif %}
 </div>


### PR DESCRIPTION
We are in the process of decommissioning D2 microapp and I noticed it is still being called by this site e.g. http://next.theguardian.com/blog/container-model-blended-content/ this removes the iframe and replaces it with a working link to .com

CC @guardian/discussion @rich-nguyen 
